### PR TITLE
Implement loop reordering mechanisms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_llvm_executable(skel
   src/DetectDynamicAction.cc
   src/AnnotateSkeletonsAction.cc
   src/DetectSkeletonsASTConsumer.cc
+  src/DetectDynamicASTConsumer.cc
   src/MapMatcher.cc
   src/Log.cc
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ add_llvm_executable(skel
   src/DynamicHandler.cc
   src/Log.cc
   src/Common.cc
+  src/LoopReorderer.cc
 )
 foreach(i
 	Analysis AST ASTMatchers Basic Driver Edit Frontend Lex Parse

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_llvm_executable(skel
   src/MapMatcher.cc
   src/DynamicHandler.cc
   src/Log.cc
+  src/Common.cc
 )
 foreach(i
 	Analysis AST ASTMatchers Basic Driver Edit Frontend Lex Parse

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_llvm_executable(skel
   src/DetectSkeletonsASTConsumer.cc
   src/DetectDynamicASTConsumer.cc
   src/MapMatcher.cc
+  src/DynamicHandler.cc
   src/Log.cc
 )
 foreach(i

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ include_directories(
 add_llvm_executable(skel
   src/main.cc
   src/DetectSkeletonsAction.cc
+  src/DetectDynamicAction.cc
   src/AnnotateSkeletonsAction.cc
   src/DetectSkeletonsASTConsumer.cc
   src/MapMatcher.cc

--- a/src/Common.cc
+++ b/src/Common.cc
@@ -1,0 +1,30 @@
+#include "Common.hh"
+
+#include <algorithm>
+#include <string>
+
+using std::vector;
+using std::string;
+
+bool allEqual(vector<string> ss) {
+  if(ss.empty()) {
+    return true;
+  }
+
+  auto first = *ss.begin();
+  return std::all_of(
+    ss.begin() + 1, ss.end(), 
+    [&](string s) { 
+      return s == first; 
+    }
+  );
+}
+
+string getDeclName(const MatchFinder::MatchResult &Result, string binding) {
+  auto decl = Result.Nodes.getNodeAs<VarDecl>(binding);
+  if(decl) {
+    return decl->getNameAsString();
+  } else {
+    return string("");
+  }
+}

--- a/src/Common.hh
+++ b/src/Common.hh
@@ -1,0 +1,17 @@
+#ifndef COMMON_HH
+#define COMMON_HH
+
+#include <vector>
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+using std::vector;
+using std::string;
+using namespace clang;
+using namespace clang::ast_matchers;
+
+bool allEqual(vector<string> ss);
+string getDeclName(const MatchFinder::MatchResult &Result, string binding);
+
+#endif

--- a/src/DetectDynamicASTConsumer.cc
+++ b/src/DetectDynamicASTConsumer.cc
@@ -1,0 +1,8 @@
+#include "DetectDynamicASTConsumer.hh"
+
+DetectDynamicASTConsumer::DetectDynamicASTConsumer()
+{
+}
+
+void DetectDynamicASTConsumer::HandleTranslationUnit(ASTContext &context) {
+}

--- a/src/DetectDynamicASTConsumer.cc
+++ b/src/DetectDynamicASTConsumer.cc
@@ -2,7 +2,9 @@
 
 DetectDynamicASTConsumer::DetectDynamicASTConsumer()
 {
+  Matcher.addMatcher(handler.matcher(), &handler);
 }
 
 void DetectDynamicASTConsumer::HandleTranslationUnit(ASTContext &context) {
+  Matcher.matchAST(context);
 }

--- a/src/DetectDynamicASTConsumer.hh
+++ b/src/DetectDynamicASTConsumer.hh
@@ -2,6 +2,7 @@
 #define DETECT_DYNAMIC_AST_CONSUMER_H
 
 #include <clang/AST/ASTConsumer.h>
+#include <clang/Sema/SemaConsumer.h>
 #include <clang/ASTMatchers/ASTMatchers.h>
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 
@@ -10,7 +11,7 @@
 using namespace clang;
 using namespace clang::ast_matchers;
 
-class DetectDynamicASTConsumer : public ASTConsumer {
+class DetectDynamicASTConsumer : public SemaConsumer {
   public:
     DetectDynamicASTConsumer();
     void HandleTranslationUnit(ASTContext &context);

--- a/src/DetectDynamicASTConsumer.hh
+++ b/src/DetectDynamicASTConsumer.hh
@@ -5,6 +5,8 @@
 #include <clang/ASTMatchers/ASTMatchers.h>
 #include <clang/ASTMatchers/ASTMatchFinder.h>
 
+#include "DynamicHandler.hh"
+
 using namespace clang;
 using namespace clang::ast_matchers;
 
@@ -13,6 +15,7 @@ class DetectDynamicASTConsumer : public ASTConsumer {
     DetectDynamicASTConsumer();
     void HandleTranslationUnit(ASTContext &context);
   private:
+    DynamicHandler handler;
     MatchFinder Matcher;
 };
 

--- a/src/DetectDynamicASTConsumer.hh
+++ b/src/DetectDynamicASTConsumer.hh
@@ -2,14 +2,18 @@
 #define DETECT_DYNAMIC_AST_CONSUMER_H
 
 #include <clang/AST/ASTConsumer.h>
-
-#include "MapMatcher.hh"
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
 
 using namespace clang;
+using namespace clang::ast_matchers;
+
 class DetectDynamicASTConsumer : public ASTConsumer {
   public:
     DetectDynamicASTConsumer();
     void HandleTranslationUnit(ASTContext &context);
+  private:
+    MatchFinder Matcher;
 };
 
 #endif

--- a/src/DetectDynamicASTConsumer.hh
+++ b/src/DetectDynamicASTConsumer.hh
@@ -1,0 +1,15 @@
+#ifndef DETECT_DYNAMIC_AST_CONSUMER_H
+#define DETECT_DYNAMIC_AST_CONSUMER_H
+
+#include <clang/AST/ASTConsumer.h>
+
+#include "MapMatcher.hh"
+
+using namespace clang;
+class DetectDynamicASTConsumer : public ASTConsumer {
+  public:
+    DetectDynamicASTConsumer();
+    void HandleTranslationUnit(ASTContext &context);
+};
+
+#endif

--- a/src/DetectDynamicAction.cc
+++ b/src/DetectDynamicAction.cc
@@ -1,5 +1,5 @@
 #include "DetectDynamicAction.hh"
-#include "DetectSkeletonsASTConsumer.hh"
+#include "DetectDynamicASTConsumer.hh"
 
 using std::unique_ptr;
 
@@ -8,5 +8,5 @@ DetectDynamicAction::DetectDynamicAction() {}
 unique_ptr<ASTConsumer> DetectDynamicAction::CreateASTConsumer(CompilerInstance &CI, 
                                                                  StringRef InFile) 
 {
-  return unique_ptr<ASTConsumer>(new DetectSkeletonsASTConsumer(false));
+  return unique_ptr<ASTConsumer>(new DetectDynamicASTConsumer());
 }

--- a/src/DetectDynamicAction.cc
+++ b/src/DetectDynamicAction.cc
@@ -1,0 +1,12 @@
+#include "DetectDynamicAction.hh"
+#include "DetectSkeletonsASTConsumer.hh"
+
+using std::unique_ptr;
+
+DetectDynamicAction::DetectDynamicAction() {}
+
+unique_ptr<ASTConsumer> DetectDynamicAction::CreateASTConsumer(CompilerInstance &CI, 
+                                                                 StringRef InFile) 
+{
+  return unique_ptr<ASTConsumer>(new DetectSkeletonsASTConsumer(false));
+}

--- a/src/DetectDynamicAction.hh
+++ b/src/DetectDynamicAction.hh
@@ -1,0 +1,19 @@
+#ifndef DETECT_DYNAMIC_HH
+#define DETECT_DYNAMIC_HH
+
+#include <string>
+
+#include <clang/Frontend/FrontendActions.h>
+#include <clang/AST/ASTConsumer.h>
+
+using namespace llvm;
+using namespace clang;
+using std::unique_ptr;
+
+class DetectDynamicAction : public ASTFrontendAction {
+  public:
+    DetectDynamicAction();
+    unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI, StringRef InFile);
+};
+
+#endif

--- a/src/DetectDynamicAction.hh
+++ b/src/DetectDynamicAction.hh
@@ -3,8 +3,8 @@
 
 #include <string>
 
-#include <clang/Frontend/FrontendActions.h>
 #include <clang/AST/ASTConsumer.h>
+#include <clang/Frontend/FrontendActions.h>
 
 using namespace llvm;
 using namespace clang;

--- a/src/DetectSkeletonsASTConsumer.cc
+++ b/src/DetectSkeletonsASTConsumer.cc
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "DetectSkeletonsASTConsumer.hh"
 
 DetectSkeletonsASTConsumer::DetectSkeletonsASTConsumer(bool overwrite) :

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -16,13 +16,36 @@ StatementMatcher DynamicHandler::forLoopMatcher() {
 }
 
 StatementMatcher DynamicHandler::initMatcher() {
-  return stmt();
+  return (
+    declStmt(hasSingleDecl(
+      varDecl(
+        hasInitializer(ignoringParenImpCasts(integerLiteral()))
+      ).bind("initVar")
+    ))
+  );
 }
 
 StatementMatcher DynamicHandler::conditionMatcher() {
-  return expr();
+  return (
+    binaryOperator(
+      hasOperatorName("<"),
+      hasLHS(ignoringParenImpCasts(
+        declRefExpr(to(varDecl(hasType(isInteger())).bind("condVar")))
+      )),
+      hasRHS(ignoringParenImpCasts(
+        expr(hasType(isInteger()))
+      ))
+    )
+  );
 }
 
 StatementMatcher DynamicHandler::incrementMatcher() {
-  return stmt();
+  return (
+    unaryOperator(
+      hasOperatorName("++"),
+      hasUnaryOperand(ignoringParenImpCasts(
+        declRefExpr(to(varDecl(hasType(isInteger())).bind("incVar")))
+      ))
+    )
+  );
 }

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -31,7 +31,7 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
     log(Debug, "Found reorderable loop");
 
     Rewriter r(*Result.SourceManager, LangOptions());
-    LoopReorderer lro(Strategy::Reverse);
+    LoopReorderer lro(Strategy::Reverse, *Result.Context);
     string newSource = lro.transform(forS);
 
     r.ReplaceText(forS->getSourceRange(), newSource);

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -1,8 +1,30 @@
+#include "Common.hh"
 #include "DynamicHandler.hh"
 #include "Log.hh"
 
+using namespace clang;
+using namespace clang::ast_matchers;
+
 void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
   log(Debug, "Handling possible reorderable loop");
+
+  if(const ForStmt *forS = Result.Nodes.getNodeAs<ForStmt>("for")) {
+    vector<string> bindings = { "initVar", "condVar", "incVar" };
+
+    std::transform(
+      bindings.begin(), bindings.end(), bindings.begin(), 
+      [&](string s) { 
+        return getDeclName(Result, s); 
+      }
+    );
+
+    auto all_equal = allEqual(bindings);
+    if(!all_equal) {
+      log(Debug, "Near miss for Reorderable Loop: "
+                 "For loop referencing different variables");
+      return;
+    }
+  }
 }
 
 StatementMatcher DynamicHandler::matcher() {

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -2,3 +2,7 @@
 
 void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
 }
+
+StatementMatcher DynamicHandler::matcher() {
+  return stmt();
+}

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -1,6 +1,7 @@
 #include "Common.hh"
 #include "DynamicHandler.hh"
 #include "Log.hh"
+#include "LoopReorderer.hh"
 
 #include <clang/Rewrite/Core/Rewriter.h>
 
@@ -30,7 +31,10 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
     log(Debug, "Found reorderable loop");
 
     Rewriter r(*Result.SourceManager, LangOptions());
-    //r.ReplaceText(forS->getSourceRange(), "");
+    LoopReorderer lro(Strategy::Reverse);
+    string newSource = lro.transform(forS);
+
+    r.ReplaceText(forS->getSourceRange(), newSource);
     r.overwriteChangedFiles();
   }
 }

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -31,7 +31,7 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
     log(Debug, "Found reorderable loop");
 
     Rewriter r(*Result.SourceManager, LangOptions());
-    LoopReorderer lro(Strategy::Reverse, *Result.Context);
+    LoopReorderer lro(Strategy::Identity, *Result.Context);
     string newSource = lro.transform(forS);
 
     r.ReplaceText(forS->getSourceRange(), newSource);

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -2,6 +2,8 @@
 #include "DynamicHandler.hh"
 #include "Log.hh"
 
+#include <clang/Rewrite/Core/Rewriter.h>
+
 using namespace clang;
 using namespace clang::ast_matchers;
 
@@ -24,6 +26,13 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
                  "For loop referencing different variables");
       return;
     }
+
+    log(Debug, "Adding comment annotation for reorderable loop");
+
+    auto loc = Result.Context->getFullLoc(forS->getLocStart());
+    Rewriter r(*Result.SourceManager, LangOptions());
+    r.InsertText(loc, "// LOOP-ORDER\n", false, true);
+    r.overwriteChangedFiles();
   }
 }
 

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -1,6 +1,8 @@
 #include "DynamicHandler.hh"
+#include "Log.hh"
 
 void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
+  log(Debug, "Handling possible reorderable loop");
 }
 
 StatementMatcher DynamicHandler::matcher() {

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -28,6 +28,10 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
     }
 
     log(Debug, "Found reorderable loop");
+
+    Rewriter r(*Result.SourceManager, LangOptions());
+    //r.ReplaceText(forS->getSourceRange(), "");
+    r.overwriteChangedFiles();
   }
 }
 

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -4,5 +4,25 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
 }
 
 StatementMatcher DynamicHandler::matcher() {
+  return forLoopMatcher();
+}
+
+StatementMatcher DynamicHandler::forLoopMatcher() {
+  return forStmt(
+    hasLoopInit(initMatcher()),
+    hasCondition(conditionMatcher()),
+    hasIncrement(incrementMatcher())
+  ).bind("for");
+}
+
+StatementMatcher DynamicHandler::initMatcher() {
+  return stmt();
+}
+
+StatementMatcher DynamicHandler::conditionMatcher() {
+  return expr();
+}
+
+StatementMatcher DynamicHandler::incrementMatcher() {
   return stmt();
 }

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -1,0 +1,4 @@
+#include "DynamicHandler.hh"
+
+void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
+}

--- a/src/DynamicHandler.hh
+++ b/src/DynamicHandler.hh
@@ -7,7 +7,9 @@
 using namespace clang::ast_matchers;
 
 class DynamicHandler : public MatchFinder::MatchCallback {
-  virtual void run(const MatchFinder::MatchResult &Result);
+  public:
+    virtual void run(const MatchFinder::MatchResult &Result);
+    StatementMatcher matcher();
 };
 
 #endif

--- a/src/DynamicHandler.hh
+++ b/src/DynamicHandler.hh
@@ -1,0 +1,13 @@
+#ifndef DYNAMIC_HANDLER_H
+#define DYNAMIC_HANDLER_H
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+using namespace clang::ast_matchers;
+
+class DynamicHandler : public MatchFinder::MatchCallback {
+  virtual void run(const MatchFinder::MatchResult &Result);
+};
+
+#endif

--- a/src/DynamicHandler.hh
+++ b/src/DynamicHandler.hh
@@ -10,6 +10,11 @@ class DynamicHandler : public MatchFinder::MatchCallback {
   public:
     virtual void run(const MatchFinder::MatchResult &Result);
     StatementMatcher matcher();
+  private:
+    StatementMatcher forLoopMatcher();
+    StatementMatcher initMatcher();
+    StatementMatcher conditionMatcher();
+    StatementMatcher incrementMatcher();
 };
 
 #endif

--- a/src/LoopReorderer.cc
+++ b/src/LoopReorderer.cc
@@ -1,6 +1,9 @@
 #include "LoopReorderer.hh"
 
+#include <sstream>
+
 using std::string;
+using std::stringstream;
 using namespace clang;
 using namespace llvm;
 
@@ -12,7 +15,22 @@ string LoopReorderer::code(const Stmt *stmt) {
 }
 
 string LoopReorderer::transform(const ForStmt *stmt) {
-  return code(stmt);
+  switch(strategy) {
+    case Strategy::Reverse:
+      return reverse(stmt);
+    default:
+      return identity(stmt);
+  }
+}
+
+string LoopReorderer::identity(const ForStmt *stmt) {
+  stringstream st;
+  st << "for ("
+     << code(stmt->getInit())
+     << code(stmt->getCond()) << "; "
+     << code(stmt->getInc()) << ") "
+     << code(stmt->getBody());
+  return st.str();
 }
 
 string LoopReorderer::reverse(const ForStmt *stmt) {

--- a/src/LoopReorderer.cc
+++ b/src/LoopReorderer.cc
@@ -1,0 +1,8 @@
+#include "LoopReorderer.hh"
+
+using std::string;
+using namespace clang;
+
+string LoopReorderer::transform(const ForStmt *stmt) {
+  return "";
+}

--- a/src/LoopReorderer.cc
+++ b/src/LoopReorderer.cc
@@ -2,7 +2,19 @@
 
 using std::string;
 using namespace clang;
+using namespace llvm;
+
+string LoopReorderer::code(const Stmt *stmt) {
+  string out;
+  raw_string_ostream stream(out);
+  stmt->printPretty(stream, nullptr, PrintingPolicy(context.getLangOpts()));
+  return out;
+}
 
 string LoopReorderer::transform(const ForStmt *stmt) {
+  return code(stmt);
+}
+
+string LoopReorderer::reverse(const ForStmt *stmt) {
   return "";
 }

--- a/src/LoopReorderer.hh
+++ b/src/LoopReorderer.hh
@@ -9,6 +9,7 @@
 struct Strategy {
   public:
     enum Type {
+      Identity,
       Reverse
     };
 
@@ -29,6 +30,7 @@ class LoopReorderer {
     Strategy strategy;
     clang::ASTContext &context;
     std::string code(const clang::Stmt *stmt);
+    std::string identity(const clang::ForStmt *stmt);
     std::string reverse(const clang::ForStmt *stmt);
 };
 

--- a/src/LoopReorderer.hh
+++ b/src/LoopReorderer.hh
@@ -1,0 +1,30 @@
+#ifndef LOOP_REORDERER_H
+#define LOOP_REORDERER_H
+
+#include <string>
+
+#include <clang/AST/AST.h>
+
+struct Strategy {
+  public:
+    enum Type {
+      Reverse
+    };
+
+    Type t_;
+    Strategy(Type t) : t_(t) {}
+    operator Type () const {return t_;}
+  private:
+    template <typename T>
+      operator T () const;
+};
+
+class LoopReorderer {
+  public:
+    LoopReorderer(Strategy s) : strategy(s) {}
+    std::string transform(const clang::ForStmt *stmt);
+  private:
+    Strategy strategy;
+};
+
+#endif

--- a/src/LoopReorderer.hh
+++ b/src/LoopReorderer.hh
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <clang/AST/AST.h>
+#include <llvm/Support/raw_ostream.h>
 
 struct Strategy {
   public:
@@ -27,6 +28,8 @@ class LoopReorderer {
   private:
     Strategy strategy;
     clang::ASTContext &context;
+    std::string code(const clang::Stmt *stmt);
+    std::string reverse(const clang::ForStmt *stmt);
 };
 
 #endif

--- a/src/LoopReorderer.hh
+++ b/src/LoopReorderer.hh
@@ -21,10 +21,12 @@ struct Strategy {
 
 class LoopReorderer {
   public:
-    LoopReorderer(Strategy s) : strategy(s) {}
+    LoopReorderer(Strategy s, clang::ASTContext &c) : 
+      strategy(s), context(c) {}
     std::string transform(const clang::ForStmt *stmt);
   private:
     Strategy strategy;
+    clang::ASTContext &context;
 };
 
 #endif

--- a/src/MapMatcher.cc
+++ b/src/MapMatcher.cc
@@ -8,34 +8,13 @@
 #include <clang/Rewrite/Core/Rewriter.h>
 #include <clang/Basic/LangOptions.h>
 
+#include "Common.hh"
 #include "Log.hh"
 
 using std::vector;
 using std::string;
 using namespace clang;
 using namespace clang::ast_matchers;
-
-namespace {
-
-static string getDeclName(const MatchFinder::MatchResult &Result, string binding) {
-  auto decl = Result.Nodes.getNodeAs<VarDecl>(binding);
-  if(decl) {
-    return decl->getNameAsString();
-  } else {
-    return string("");
-  }
-}
-
-static bool allEqual(vector<string> ss) {
-  if(ss.size() < 1) {
-    return true;
-  }
-
-  auto first = *ss.begin();
-  return std::all_of(ss.begin() + 1, ss.end(), [&](string s) { return s == first; });
-}
-
-}
 
 MapHandler::MapHandler(bool o) : overwrite(o) {}
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -5,6 +5,7 @@
 #include <llvm/Support/CommandLine.h>
 
 #include "DetectSkeletonsAction.hh"
+#include "DetectDynamicAction.hh"
 #include "AnnotateSkeletonsAction.hh"
 #include "Log.hh"
 
@@ -14,6 +15,8 @@ using namespace clang::tooling;
 using std::string;
 
 static cl::OptionCategory OptionsCategory("skel options");
+static cl::opt<bool> Static("static", cl::desc("Perform static analysis"),
+                            cl::cat(OptionsCategory));
 static cl::opt<bool> Overwrite("overwrite", cl::desc("Overwrite source files"), 
                                cl::cat(OptionsCategory));
 static cl::alias OverwriteA("w", cl::desc("Alias for -overwrite"), cl::aliasopt(Overwrite));
@@ -22,9 +25,13 @@ int main(int argc, const char **argv) {
   CommonOptionsParser op(argc, argv, OptionsCategory);
   ClangTool Tool(op.getCompilations(), op.getSourcePathList());
   
-  if(Overwrite) {
-    return Tool.run(newFrontendActionFactory<AnnotateSkeletonsAction>().get());
-  } else {
-    return Tool.run(newFrontendActionFactory<DetectSkeletonsAction>().get());
+  if(Static) {
+    if(Overwrite) {
+      return Tool.run(newFrontendActionFactory<AnnotateSkeletonsAction>().get());
+    } else {
+      return Tool.run(newFrontendActionFactory<DetectSkeletonsAction>().get());
+    }
   }
+
+  return Tool.run(newFrontendActionFactory<DetectDynamicAction>().get());
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -14,22 +14,34 @@ using namespace clang;
 using namespace clang::tooling;
 using std::string;
 
+enum ProgramMode {
+  Static,
+  FindReorderable
+};
+
 static cl::OptionCategory OptionsCategory("skel options");
-static cl::opt<bool> Static("static", cl::desc("Perform static analysis"),
-                            cl::cat(OptionsCategory));
 static cl::opt<bool> Overwrite("overwrite", cl::desc("Overwrite source files"), 
                                cl::cat(OptionsCategory));
 static cl::alias OverwriteA("w", cl::desc("Alias for -overwrite"), cl::aliasopt(Overwrite));
+
+static cl::opt<ProgramMode> Mode(cl::desc("choose application mode"),
+    cl::values(
+      clEnumVal(Static, "Statically analyse the program"),
+      clEnumVal(FindReorderable, "Dynamically find reorderable loops"),
+      nullptr
+    ), cl::cat(OptionsCategory), cl::Required);
 
 int main(int argc, const char **argv) {
   CommonOptionsParser op(argc, argv, OptionsCategory);
   ClangTool Tool(op.getCompilations(), op.getSourcePathList());
   
-  if(Static) {
+  if(Mode == Static) {
     if(Overwrite) {
-      return Tool.run(newFrontendActionFactory<AnnotateSkeletonsAction>().get());
+      return Tool.run(
+          newFrontendActionFactory<AnnotateSkeletonsAction>().get());
     } else {
-      return Tool.run(newFrontendActionFactory<DetectSkeletonsAction>().get());
+      return Tool.run(
+          newFrontendActionFactory<DetectSkeletonsAction>().get());
     }
   }
 


### PR DESCRIPTION
This PR introduces some mechanisms by which candidate loops can be reordered within a program. To do this, I splice pretty-printed representations of AST nodes back into the appropriate locations in the code.