### PR TITLE
Implement scripts for interacting

### DIFF
--- a/scripts/annotate.sh
+++ b/scripts/annotate.sh
@@ -1,0 +1,28 @@
+#! /usr/local/bin/bash
+
+usage() {
+  echo "Usage $0 y|n|m manifest"
+}
+
+if [ $# -ne 2 ]
+then
+  usage
+  exit 1
+fi
+
+line=$(head -n1 $2 | tail -1)
+file=$(head -n2 $2 | tail -1)
+
+case $1 in
+  y*)
+    replace="PAR_FOR"
+    ;;
+  n*)
+    replace="NO_PAR_FOR"
+    ;;
+  m*)
+    replace="MAYBE_PAR_FOR"
+    ;;
+esac
+
+sed -i '' $line's/for/'$replace'/' $file

--- a/scripts/loops.c
+++ b/scripts/loops.c
@@ -1,9 +1,8 @@
 #include <stdio.h>
 
 int loopy() {
-  volatile int x;
-  int i;
-  for(i = 0; i < 10; i++) {
+  int x = 0;
+  for(int i = 0; i < 10; i++) {
     printf("%d\n", i);
     x+=i;
   }

--- a/scripts/reorder.sh
+++ b/scripts/reorder.sh
@@ -51,5 +51,7 @@ do
   s+="_"
   base=$(basename $filename)
   cp $filename "$output_dir/$s$base"
-  skel -reorder -$strat "$output_dir/$s$base" --
+  line=$(skel -reorder -$strat "$output_dir/$s$base" --)
+  echo $line
+  echo "$base"
 done

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,33 @@
+#! /usr/local/bin/bash
+
+usage() {
+  echo "Usage: $0 manifest name strats..."
+}
+
+if [ $# -le 2 ]
+then
+  usage
+  exit 1
+fi
+
+manifest=$1
+shift
+
+exe=$1
+shift
+
+strats="$@"
+
+good=$(./"$exe" $ARGS)
+
+for strat in ${strats[@]}
+do
+  out=$(./"$strat"_$exe $ARGS)
+  if [ "$out" != "$good" ]
+  then
+    ./annotate.sh n $manifest
+    exit 0
+  fi
+done
+
+./annotate.sh m $manifest

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -92,7 +92,10 @@ StatementMatcher DynamicHandler::initMatcher() {
 StatementMatcher DynamicHandler::conditionMatcher() {
   return (
     binaryOperator(
-      hasOperatorName("<"),
+      anyOf(
+        hasOperatorName("<"),
+        hasOperatorName("<=")
+      ),
       hasLHS(ignoringParenImpCasts(
         declRefExpr(to(varDecl(hasType(isInteger())).bind("condVar")))
       )),

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -54,6 +54,10 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
     r.ReplaceText(forS->getSourceRange(), newSource);
     r.overwriteChangedFiles();
 
+    llvm::outs() 
+      << Result.Context->getFullLoc(forS->getLocStart()).getSpellingLineNumber() 
+      << '\n';
+
     exit(0);
   }
 }

--- a/src/DynamicHandler.cc
+++ b/src/DynamicHandler.cc
@@ -51,6 +51,8 @@ void DynamicHandler::run(const MatchFinder::MatchResult &Result) {
 
     r.ReplaceText(forS->getSourceRange(), newSource);
     r.overwriteChangedFiles();
+
+    exit(0);
   }
 }
 

--- a/src/Loop.hh
+++ b/src/Loop.hh
@@ -23,6 +23,12 @@ struct Loop {
   std::string var;
 
   /**
+   * Whether the loop has declared its induction variable inline (as is
+   * permitted in C99 onwards).
+   */
+  bool declared;
+
+  /**
    * The initializer for the loop induction variable. For example, 0 in:
    * 
    *     for (int i = 0; i < N; i++) {}
@@ -40,9 +46,10 @@ struct Loop {
 
   Loop(const clang::ForStmt *fs, 
        std::string v, 
+       bool d,
        const clang::Stmt *i, 
        const clang::Stmt *b) :
-    stmt(fs), var(v), init(i), bound(b) {}
+    stmt(fs), var(v), declared(d), init(i), bound(b) {}
 };
 
 #endif

--- a/src/LoopReorderer.cc
+++ b/src/LoopReorderer.cc
@@ -43,6 +43,7 @@ string LoopReorderer::identity(Loop loop) {
 string LoopReorderer::reverse(Loop loop) {
   stringstream st;
   st << "for ("
+     << (loop.declared ? "int " : "")
      << loop.var << " = "
      << code(loop.bound) << " - 1;"
      << loop.var << reverseComparison(comparisonOp(loop.stmt->getCond())) 

--- a/src/LoopReorderer.cc
+++ b/src/LoopReorderer.cc
@@ -45,7 +45,8 @@ string LoopReorderer::reverse(Loop loop) {
   st << "for ("
      << (loop.declared ? "int " : "")
      << loop.var << " = "
-     << code(loop.bound) << " - 1;"
+     << code(loop.bound) << " - " 
+     << reverseBound(comparisonOp(loop.stmt->getCond())) << "; "
      << loop.var << reverseComparison(comparisonOp(loop.stmt->getCond())) 
      << code(loop.init) << "; "
      << loop.var << "--)"

--- a/src/LoopReorderer.cc
+++ b/src/LoopReorderer.cc
@@ -33,7 +33,7 @@ string LoopReorderer::identity(Loop loop) {
   stringstream st;
 
   st << "for ("
-     << code(stmt->getInit()) << "; "
+     << code(stmt->getInit()) << (loop.declared ? "" : ";")
      << code(stmt->getCond()) << "; "
      << code(stmt->getInc()) << ") "
      << code(stmt->getBody());


### PR DESCRIPTION
This PR introduces a set of scripts for interacting with the dynamic parallelism finder. They can be used to compile simple C projects with a file to be experimented on, as well as executing, comparing results and annotating the original source file with findings.